### PR TITLE
Changed reference from removed Config class to RbConfig in extconf file

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -1,4 +1,4 @@
-# 
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements. See the NOTICE file
 # distributed with this work for additional information
@@ -6,23 +6,23 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License. You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations
 # under the License.
-# 
+#
 
 if defined?(RUBY_ENGINE) && RUBY_ENGINE =~ /jruby/
   File.open('Makefile', 'w'){|f| f.puts "all:\n\ninstall:\n" }
 else
   require 'mkmf'
 
-  $ARCH_FLAGS = Config::CONFIG['CFLAGS'].scan( /(-arch )(\S+)/ ).map{|x,y| x + y + ' ' }.join('')
+  $ARCH_FLAGS = ::RbConfig::CONFIG['CFLAGS'].scan( /(-arch )(\S+)/ ).map{|x,y| x + y + ' ' }.join('')
 
   $CFLAGS = "-fsigned-char -g -O2 -Wall -Werror " + $ARCH_FLAGS
 


### PR DESCRIPTION
As mentioned in this [stackoverflow answer](http://stackoverflow.com/questions/13693713/use-rbconfig-instead-of-obsolete-and-deprecated-config/14105678#14105678), using the 'Config' class was depreciated since ruby 1.9.3, and was finally removed in ruby 2.2.2. This is preventing the gem from building.

This PR is a simple change that refers to the newer 'RbConfig' class in the extconf file.
